### PR TITLE
Check for ang. error initialization with nullptr

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -187,7 +187,7 @@ private:
   // Flag that a different thread has requested a stop.
   std::atomic<bool> stop_requested_;
 
-  double angular_error_;
+  std::shared_ptr<double> angular_error_;
 };
 
 // using alias

--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -187,7 +187,7 @@ private:
   // Flag that a different thread has requested a stop.
   std::atomic<bool> stop_requested_;
 
-  std::shared_ptr<double> angular_error_;
+  std::unique_ptr<double> angular_error_;
 };
 
 // using alias

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -296,7 +296,7 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
   Eigen::AngleAxisd axis_angle(q_error);
   // Cache the angular error, for rotation tolerance checking
   if (angular_error_ == nullptr)
-    angular_error_ = std::make_shared<double>(axis_angle.angle());
+    angular_error_ = std::make_unique<double>(axis_angle.angle());
   else
     *angular_error_ = axis_angle.angle();
   double ang_vel_magnitude =

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -50,7 +50,7 @@ PoseTracking::PoseTracking(const ros::NodeHandle& nh,
   , loop_rate_(DEFAULT_LOOP_RATE)
   , transform_listener_(transform_buffer_)
   , stop_requested_(false)
-  , angular_error_(3.5)
+  , angular_error_(nullptr)
 {
   readROSParams();
 
@@ -226,8 +226,12 @@ bool PoseTracking::satisfiesPoseTolerance(const Eigen::Vector3d& positional_tole
   double y_error = target_pose_.pose.position.y - command_frame_transform_.translation()(1);
   double z_error = target_pose_.pose.position.z - command_frame_transform_.translation()(2);
 
+  // If uninitialized, likely haven't received the target pose yet.
+  if (angular_error_ == nullptr)
+    return false;
+
   return ((std::abs(x_error) < positional_tolerance(0)) && (std::abs(y_error) < positional_tolerance(1)) &&
-          (std::abs(z_error) < positional_tolerance(2)) && (std::abs(angular_error_) < angular_tolerance));
+          (std::abs(z_error) < positional_tolerance(2)) && (std::abs(*angular_error_) < angular_tolerance));
 }
 
 void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& msg)
@@ -291,9 +295,12 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
   // Convert axis-angle to angular velocity
   Eigen::AngleAxisd axis_angle(q_error);
   // Cache the angular error, for rotation tolerance checking
-  angular_error_ = axis_angle.angle();
+  if (angular_error_ == nullptr)
+    angular_error_ = std::make_shared<double>(axis_angle.angle());
+  else
+    *angular_error_ = axis_angle.angle();
   double ang_vel_magnitude =
-      cartesian_orientation_pids_[0].computeCommand(angular_error_, loop_rate_.expectedCycleTime());
+      cartesian_orientation_pids_[0].computeCommand(*angular_error_, loop_rate_.expectedCycleTime());
   twist.angular.x = ang_vel_magnitude * axis_angle.axis()[0];
   twist.angular.y = ang_vel_magnitude * axis_angle.axis()[1];
   twist.angular.z = ang_vel_magnitude * axis_angle.axis()[2];
@@ -306,7 +313,7 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
 void PoseTracking::doPostMotionReset()
 {
   stop_requested_ = false;
-  angular_error_ = 0;
+  angular_error_ = nullptr;
 
   // Reset error integrals and previous errors of PID controllers
   cartesian_position_pids_[0].reset();


### PR DESCRIPTION
A follow-up to MoveIt PR 2464  (https://github.com/ros-planning/moveit/pull/2464#pullrequestreview-556448157)
