### PR TITLE
replaced unique_ptr with boost::optional

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/pose_tracking.h
@@ -45,6 +45,7 @@
 #include <rosparam_shortcuts/rosparam_shortcuts.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/transform_listener.h>
+#include <boost/optional.hpp>
 
 // Conventions:
 // Calculations are done in the planning_frame_ unless otherwise noted.
@@ -187,7 +188,7 @@ private:
   // Flag that a different thread has requested a stop.
   std::atomic<bool> stop_requested_;
 
-  std::unique_ptr<double> angular_error_;
+  boost::optional<double> angular_error_;
 };
 
 // using alias


### PR DESCRIPTION
### Description

As proposed, the smart pointer is replaced by boost:optional. 
For ros-planning/moveit#2464

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
